### PR TITLE
Fix parse-slot to be able to collect accessors/readers/writers properly

### DIFF
--- a/src/parsers.lisp
+++ b/src/parsers.lisp
@@ -91,7 +91,8 @@
                  (let ((out (list)))
                    (loop while (getf (rest slot) key) do
                      (push (getf (rest slot) key) out)
-                     (remf (rest slot) key)))))
+                     (remf (rest slot) key))
+                   out)))
           (let ((accessors (extract-all-and-delete :accessor))
                 (readers (extract-all-and-delete :reader))
                 (writers (extract-all-and-delete :writer)))


### PR DESCRIPTION
class-slot-node's accessors/readers/writers is always NIL because of a bug of extract-all-and-delete.