### PR TITLE
Add 'qualifiers' to method-node and fix cl:defmethod parser.

### DIFF
--- a/src/nodes.lisp
+++ b/src/nodes.lisp
@@ -49,7 +49,10 @@
           :initarg :setfp
           :initform nil
           :type boolean
-          :documentation "Whether the method is a setf method."))
+          :documentation "Whether the method is a setf method.")
+   (qualifiers :reader method-qualifiers
+               :initarg :qualifiers
+               :initform nil))
   (:documentation "A method."))
 
 (defclass variable-node (documentation-node)

--- a/src/package.lisp
+++ b/src/package.lisp
@@ -39,6 +39,8 @@
            ;; Operators
            :operator-lambda-list
            :operator-setf-p
+           ;; Methods
+           :method-qualifiers
            ;; Slots
            :slot-accessors
            :slot-readers


### PR DESCRIPTION
* Add a slot 'qualifiers' to method-node.
* defmethod can take multiple qualifiers before its lambda-list.
* docstring can be placed before/after declarations.