### PR TITLE
Support uiop:define-package

### DIFF
--- a/src/core.lisp
+++ b/src/core.lisp
@@ -117,7 +117,8 @@
            #'(lambda (function form environment)
                (when (listp form)
                  ;; Package nodes are special cases
-                 (if (equal (first form) 'cl:defpackage)
+                 (if (or (equal (first form) 'cl:defpackage)
+                         (equal (first form) 'uiop:define-package))
                      ;; Parse the package definition, and add the new package
                      ;; index to the index
                      (let ((package-index (parse-package-definition (rest form))))


### PR DESCRIPTION
`uiop:define-package` is a macro to define a package, however it isn't parsed as a package form because it isn't expanded to `cl:defpackage`.

ref. https://github.com/quickdocs/quickdocs/issues/24