### PR TITLE
Add support for define-setf-expander.

### DIFF
--- a/src/nodes.lisp
+++ b/src/nodes.lisp
@@ -21,15 +21,16 @@
 (defclass operator-node (documentation-node)
  ((lambda-list :reader operator-lambda-list
                :initarg :lambda-list
-               :documentation "The operator's lambda list."))
+               :documentation "The operator's lambda list.")
+  (setfp :reader operator-setf-p
+         :initarg :setfp
+         :initform nil
+         :type boolean
+         :documentation "Whether the operator is a setf operation."))
   (:documentation "The base class of functions and macros."))
 
 (defclass function-node (operator-node)
-  ((setfp :reader operator-setf-p
-          :initarg :setfp
-          :initform nil
-          :type boolean
-          :documentation "Whether the function is a setf function."))
+  ()
   (:documentation "A function."))
 
 (defclass macro-node (operator-node)
@@ -37,20 +38,11 @@
   (:documentation "A macro."))
 
 (defclass generic-function-node (operator-node)
-  ((setfp :reader operator-setf-p
-          :initarg :setfp
-          :initform nil
-          :type boolean
-          :documentation "Whether the generic function's methods are setf methods."))
+  ()
   (:documentation "A generic function."))
 
 (defclass method-node (operator-node)
-  ((setfp :reader operator-setf-p
-          :initarg :setfp
-          :initform nil
-          :type boolean
-          :documentation "Whether the method is a setf method.")
-   (qualifiers :reader method-qualifiers
+  ((qualifiers :reader method-qualifiers
                :initarg :qualifiers
                :initform nil))
   (:documentation "A method."))

--- a/src/parsers.lisp
+++ b/src/parsers.lisp
@@ -23,6 +23,14 @@
                    :docstring docstring
                    :lambda-list args)))
 
+(define-parser cl:define-setf-expander (name (&rest args) &rest body)
+  (let ((docstring (extract-docstring body)))
+    (make-instance 'macro-node
+                   :name name
+                   :docstring docstring
+                   :lambda-list args
+                   :setfp t)))
+
 (define-parser cl:defgeneric (name (&rest args) &rest options)
   (let ((docstring (second (find :documentation options :key #'first))))
     (make-instance 'generic-function-node


### PR DESCRIPTION
Also made all operators have operator-setf-p.

I'm not sure if a setf-expander should be considered a macro or a different kind of operator. But I think at the very least operator-setf-p should be defined for all operators.