### PR TITLE
Fix macroexpand hook in parse-system

### DIFF
--- a/src/core.lisp
+++ b/src/core.lisp
@@ -150,13 +150,13 @@
                          (when *store-form*
                            (setf (node-form node) form))
                          (add-node index node))
-                       t))
+                       t)))
                ;; Always pass the form to the old macroexpander. This ensures
                ;; the system is loaded properly.
                (funcall old-macroexpander
                         function
                         form
-                        environment)))))
+                        environment))))
     (load-system system-name)))
 
 ;;; External interface

--- a/t/test-system.lisp
+++ b/t/test-system.lisp
@@ -71,6 +71,11 @@
 
 (indirectly-define-function)
 
+(defun local-symbol-macro ()
+  (flet (((setf thing) (new-value) new-value))
+    (symbol-macrolet ((thing (thing)))
+      (setf thing 1))))
+
 ;;; CFFI stuff
 
 (cffi:defcfun printf :int


### PR DESCRIPTION
The hook only called the old macroexpand hook if the form being expanded
was a list. This lead to e.g. symbol-macros not being passed to the old
macroexpand hook.