### PR TITLE
Add support for initarg and initform in class slot nodes

### DIFF
--- a/src/equal.lisp
+++ b/src/equal.lisp
@@ -47,6 +47,9 @@
        (equal (slot-writers a) (slot-writers b))
        (equal (slot-or-nil a 'type) (slot-or-nil b 'type))
        (eq (slot-allocation a) (slot-allocation b))
+       (equal (slot-or-nil a 'initarg) (slot-or-nil b 'initarg))
+       (equal (multiple-value-list (slot-initform a))
+              (multiple-value-list (slot-initform b)))
        (call-next-method)))
 
 (define-equality (a b struct-node)

--- a/src/nodes.lisp
+++ b/src/nodes.lisp
@@ -72,12 +72,25 @@
    (type :reader slot-type
          :initarg :type
          :documentation "The slot's type.")
+   (initarg :reader slot-initarg
+            :initarg :initarg
+            :documentation "The slot's initarg.")
+   (initform :initarg :initform
+             :documentation "The slot's initform.")
    (allocation :reader slot-allocation
                :initarg :allocation
                :initform :instance
                :type keyword
                :documentation "The slot's allocation type."))
   (:documentation "A class or structure slot."))
+
+(defun slot-initform (class-slot-node)
+  "Return the initform for the slot.
+Also returns a second boolean value indicating whether the slot has an initform,
+so an initform of NIL can be distinguished from not having an initform at all."
+  (if (slot-boundp class-slot-node 'initform)
+    (values (slot-value class-slot-node 'initform) t)
+    (values nil nil)))
 
 (defclass record-node (documentation-node)
   ()

--- a/src/package.lisp
+++ b/src/package.lisp
@@ -49,6 +49,8 @@
            :slot-writers
            :slot-type
            :slot-allocation
+           :slot-initarg
+           :slot-initform
            ;; Records and classes
            :record-slots
            :class-node-superclasses)

--- a/src/parsers.lisp
+++ b/src/parsers.lisp
@@ -112,15 +112,18 @@ Correctly handles bodies where the first form is a declaration."
                                         ;; For metaclass stuff
                                         &allow-other-keys)
                 slot
-              (declare (ignore initarg initform))
-              (make-instance 'class-slot-node
-                             :name name
-                             :docstring documentation
-                             :type type
-                             :allocation allocation
-                             :accessors accessors
-                             :readers readers
-                             :writers writers)))))
+              (let ((node (make-instance 'class-slot-node
+                                         :name name
+                                         :docstring documentation
+                                         :type type
+                                         :allocation allocation
+                                         :accessors accessors
+                                         :readers readers
+                                         :writers writers
+                                         :initarg initarg)))
+                (when (member :initform slot)
+                  (setf (slot-value node 'initform) initform))
+                node)))))
       (make-instance 'class-slot-node
                      :name slot)))
 

--- a/t/docparser.lisp
+++ b/t/docparser.lisp
@@ -93,12 +93,25 @@
     (with-test-node (node docparser:class-node "TEST-CLASS")
       (is (equal (length (docparser:record-slots node))
                  3))
-      (let ((first-slot (first (docparser:record-slots node))))
+      (let ((first-slot (first (docparser:record-slots node)))
+            (second-slot (second (docparser:record-slots node))))
         (is
          (typep first-slot 'docparser:class-slot-node))
         (is
          (equal (symbol-name (docparser:node-name first-slot))
                 "FIRST-SLOT"))
+        (is
+          (equal :first-slot
+                 (docparser:slot-initarg first-slot)))
+        (is
+          (equal (list nil nil)
+                 (multiple-value-list (docparser:slot-initform first-slot))))
+        (is
+          (equal :second-slot
+                 (docparser:slot-initarg second-slot)))
+        (is
+          (equal (list "initform" t)
+                 (multiple-value-list (docparser:slot-initform second-slot))))
         (is
          (equal (docparser:node-docstring first-slot)
                 "docstring"))))

--- a/t/test-system.lisp
+++ b/t/test-system.lisp
@@ -45,6 +45,7 @@
    (second-slot :reader second-slot
                 :reader s-slot
                 :initarg :second-slot
+                :initform "initform"
                 :documentation "docstring")
    third-slot)
   (:documentation "docstring"))


### PR DESCRIPTION
I took a stab at implementing https://github.com/eudoxia0/docparser/issues/17

This is a bit hairy because we need to be able to distinguish `initform`s of `NIL` from not having an `initform` defined at all.  I'm pretty new to Common Lisp so there's probably a cleaner way to do this -- feel free to close this if so.