### PR TITLE
Added :metaclass and :default-initargs parsing for classes for class-…

### DIFF
--- a/src/equal.lisp
+++ b/src/equal.lisp
@@ -58,6 +58,8 @@
 
 (define-equality (a b class-node)
   (and (equal (class-node-superclasses a) (class-node-superclasses b))
+       (equal (class-node-metaclass a) (class-node-metaclass b))
+       (equal (class-node-default-initargs a) (class-node-default-initargs b))
        (every #'node= (record-slots a) (record-slots b))
        (call-next-method)))
 

--- a/src/nodes.lisp
+++ b/src/nodes.lisp
@@ -113,6 +113,14 @@ so an initform of NIL can be distinguished from not having an initform at all."
                  :initarg :superclasses
                  :type (proper-list symbol)
                  :documentation "A list of the class's superclasses (symbols).")
+   (metaclass :reader class-node-metaclass
+              :initarg :metaclass
+              :type symbol
+              :documentation "The class's metaclass (symbol).")
+   (default-initargs :reader class-node-default-initargs
+                     :initarg :default-initargs
+                     :type (proper-list)
+                     :documentation "The class's metaclass (symbol).")
    (slots :reader record-slots
           :initarg :slots
           :type (proper-list class-slot-node)

--- a/src/parsers.lisp
+++ b/src/parsers.lisp
@@ -128,10 +128,14 @@ Correctly handles bodies where the first form is a declaration."
                      :name slot)))
 
 (define-parser cl:defclass (name superclasses slots &rest options)
-  (let ((docstring (second (find :documentation options :key #'first))))
+  (let ((docstring (second (find :documentation options :key #'first)))
+        (metaclass (second (find :metaclass options :key #'first)))
+        (default-initargs (cdr (find :default-initargs options :key #'first))))
     (make-instance 'class-node
                    :name name
                    :superclasses superclasses
+                   :metaclass (if metaclass metaclass 'cl:standard-class)
+                   :default-initargs default-initargs
                    :slots (loop for slot in slots collecting
                             (parse-slot slot))
                    :docstring docstring)))


### PR DESCRIPTION
Adds parsing of the :metaclass and :default-initargs options for classes for class-nodes. The metaclass is extracted as a symbol and defaulted to ``'standard-class`` when it isn't given, and default-initargs is extracted as a list.