### PR TITLE
Add struct options

### DIFF
--- a/src/equal.lisp
+++ b/src/equal.lisp
@@ -63,6 +63,8 @@
   (and (every #'node= (record-slots a) (record-slots b))
        (equal (struct-node-conc-name a) (struct-node-conc-name b))
        (equal (struct-node-copier a) (struct-node-copier b))
+       (equal (struct-node-include-name a) (struct-node-include-name b))
+       (every #'node= (struct-node-include-slots a) (struct-node-include-slots b))
        (equal (struct-node-initial-offset a) (struct-node-initial-offset b))
        (equal (struct-node-named a) (struct-node-named b))
        (equal (struct-node-predicate a) (struct-node-predicate b))

--- a/src/equal.lisp
+++ b/src/equal.lisp
@@ -61,6 +61,14 @@
 
 (define-equality (a b struct-node)
   (and (every #'node= (record-slots a) (record-slots b))
+       (equal (struct-node-conc-name a) (struct-node-conc-name b))
+       (equal (struct-node-copier a) (struct-node-copier b))
+       (equal (struct-node-initial-offset a) (struct-node-initial-offset b))
+       (equal (struct-node-named a) (struct-node-named b))
+       (equal (struct-node-predicate a) (struct-node-predicate b))
+       (equal (struct-node-print-function a) (struct-node-print-function b))
+       (equal (struct-node-print-object a) (struct-node-print-object b))
+       (equal (struct-node-type a) (struct-node-type b))
        (call-next-method)))
 
 (define-equality (a b class-node)

--- a/src/equal.lisp
+++ b/src/equal.lisp
@@ -62,6 +62,7 @@
 (define-equality (a b struct-node)
   (and (every #'node= (record-slots a) (record-slots b))
        (equal (struct-node-conc-name a) (struct-node-conc-name b))
+       (equal (struct-node-constructor a) (struct-node-constructor b))
        (equal (struct-node-copier a) (struct-node-copier b))
        (equal (struct-node-include-name a) (struct-node-include-name b))
        (every #'node= (struct-node-include-slots a) (struct-node-include-slots b))

--- a/src/nodes.lisp
+++ b/src/nodes.lisp
@@ -115,7 +115,46 @@ so an initform of NIL can be distinguished from not having an initform at all."
   ((slots :reader record-slots
           :initarg :slots
           :type (proper-list struct-slot-node)
-          :documentation "A list of slots."))
+          :documentation "A list of slots.")
+   (conc-name :reader struct-node-conc-name
+              :initarg :conc-name
+              :type string
+              :documentation
+              "The prefix used for the struct's slot accessors.")
+   (copier :reader struct-node-copier
+           :initarg :copier
+           :type symbol
+           :documentation "The copier function.")
+   (initial-offset :reader struct-node-initial-offset
+                   :initarg :initial-offset
+                   :type (or null (integer 0))
+                   :documentation
+                   "The structure's initial offset (integer), or nil if :type
+                    was not given.")
+   (named :reader struct-node-named
+          :initarg :named
+          :type boolean
+          :documentation
+          "Whether the structure is named or not.")
+   (predicate :reader struct-node-predicate
+              :initarg :predicate
+              :type symbol
+              :documentation "The predicate function.")
+   (print-function :reader struct-node-print-function
+                   :initarg :print-function
+                   :type symbol
+                   :documentation
+                   "The print-function function, or nil if there is none.")
+   (print-object :reader struct-node-print-object
+                 :initarg :print-object
+                 :type symbol
+                 :documentation
+                 "The print-object function, or nil if there is none.")
+   (type :reader struct-node-type
+         :initarg :type
+         :type (or null symbol (cons symbol (cons (or symbol list) null)))
+         :documentation
+         "The structure's representation."))
   (:documentation "A structure."))
 
 (defclass class-node (record-node)

--- a/src/nodes.lisp
+++ b/src/nodes.lisp
@@ -125,6 +125,15 @@ so an initform of NIL can be distinguished from not having an initform at all."
            :initarg :copier
            :type symbol
            :documentation "The copier function.")
+   (include-name :reader struct-node-include-name
+                 :initarg :include-name
+                 :type symbol
+                 :documentation
+                 "Structure that this one inherits from, if any.")
+   (include-slots :reader struct-node-include-slots
+                  :initarg :include-slots
+                  :type (proper-list struct-slot-node)
+                  :documentation "Included structure slot descriptions.")
    (initial-offset :reader struct-node-initial-offset
                    :initarg :initial-offset
                    :type (or null (integer 0))

--- a/src/nodes.lisp
+++ b/src/nodes.lisp
@@ -121,6 +121,13 @@ so an initform of NIL can be distinguished from not having an initform at all."
               :type string
               :documentation
               "The prefix used for the struct's slot accessors.")
+   (constructor :reader struct-node-constructor
+                :initarg :constructor
+                :type (or symbol proper-list)
+                :documentation
+                "The constructor; which is nil if there is none, the
+                 constructor's symbol, or a list of the boa-constructor's
+                 symbol and arguments.")
    (copier :reader struct-node-copier
            :initarg :copier
            :type symbol

--- a/src/package.lisp
+++ b/src/package.lisp
@@ -58,6 +58,8 @@
            :record-slots
            :struct-node-conc-name
            :struct-node-copier
+           :struct-node-include-name
+           :struct-node-include-slots
            :struct-node-initial-offset
            :struct-node-named
            :struct-node-predicate

--- a/src/package.lisp
+++ b/src/package.lisp
@@ -56,6 +56,14 @@
            :slot-initform
            ;; Records and classes
            :record-slots
+           :struct-node-conc-name
+           :struct-node-copier
+           :struct-node-initial-offset
+           :struct-node-named
+           :struct-node-predicate
+           :struct-node-print-function
+           :struct-node-print-object
+           :struct-node-type
            :class-node-superclasses
            :class-node-metaclass
            :class-node-default-initargs)

--- a/src/package.lisp
+++ b/src/package.lisp
@@ -57,6 +57,7 @@
            ;; Records and classes
            :record-slots
            :struct-node-conc-name
+           :struct-node-constructor
            :struct-node-copier
            :struct-node-include-name
            :struct-node-include-slots

--- a/src/parsers.lisp
+++ b/src/parsers.lisp
@@ -192,6 +192,13 @@ Correctly handles bodies where the first form is a declaration."
                         (cond ((and key conc-name) (symbol-name conc-name))
                               ((and key (not conc-name)) "")
                               (t (concatenate 'string (symbol-name name) "-")))))
+           (constructor (destructuring-bind (&optional key (constructor nil has-constructor-p)
+                                                       args)
+                            (extract-struct-option options :constructor)
+                          (cond ((and has-constructor-p args) (cons constructor args))
+                                ((and has-constructor-p (not args)) constructor)
+                                (t (intern (concatenate 'string "MAKE-" (symbol-name name))
+                                           (symbol-package name))))))
            (copier (destructuring-bind (&optional key (copier nil has-copier-p))
                        (extract-struct-option options :copier)
                      (if has-copier-p
@@ -236,6 +243,7 @@ Correctly handles bodies where the first form is a declaration."
                        :name name
                        :docstring docstring
                        :conc-name conc-name
+                       :constructor constructor
                        :copier copier
                        :initial-offset initial-offset
                        :type type

--- a/src/parsers.lisp
+++ b/src/parsers.lisp
@@ -229,19 +229,25 @@ Correctly handles bodies where the first form is a declaration."
            (slots (if (stringp (first slots))
                       (rest slots)
                       slots)))
-      (make-instance 'struct-node
-                     :name name
-                     :docstring docstring
-                     :conc-name conc-name
-                     :copier copier
-                     :initial-offset initial-offset
-                     :type type
-                     :named named
-                     :predicate predicate
-                     :print-function print-function
-                     :print-object print-object
-                     :slots (loop for slot in slots collecting
-                                 (parse-struct-slot slot))))))
+      (destructuring-bind (&optional key include-name &rest include-slots)
+          (extract-struct-option options :include)
+        (declare (ignore key))
+        (make-instance 'struct-node
+                       :name name
+                       :docstring docstring
+                       :conc-name conc-name
+                       :copier copier
+                       :initial-offset initial-offset
+                       :type type
+                       :named named
+                       :predicate predicate
+                       :print-function print-function
+                       :print-object print-object
+                       :include-name include-name
+                       :include-slots (loop for slot in include-slots collecting
+                                           (parse-struct-slot slot))
+                       :slots (loop for slot in slots collecting
+                                   (parse-struct-slot slot)))))))
 
 ;;; CFFI parsers
 

--- a/src/parsers.lisp
+++ b/src/parsers.lisp
@@ -169,20 +169,79 @@ Correctly handles bodies where the first form is a declaration."
                           :read-only read-only)))))
 
 (define-parser cl:defstruct (name-and-options &rest slots)
-  (let ((name (if (listp name-and-options)
-                  (first name-and-options)
-                  name-and-options))
-        (docstring (if (stringp (first slots))
-                       (first slots)
-                       nil))
-        (slots (if (stringp (first slots))
-                   (rest slots)
-                   slots)))
-    (make-instance 'struct-node
-                   :name name
-                   :docstring docstring
-                   :slots (loop for slot in slots collecting
-                            (parse-struct-slot slot)))))
+  ;; Struct options can be bare keywords or be a list with the keyword being
+  ;; the first element. The following function searches for the keyword in
+  ;; either form and if it finds it, returns it in list form with the
+  ;; keyword as the first item (that way one can tell between it and nil).
+  (flet ((extract-struct-option (options key)
+           (let ((entry (find key options
+                              :key
+                              #'(lambda (el) (if (and (listp el) el)
+                                                 (first el)
+                                                 el)))))
+             (if (listp entry)
+                 entry
+                 (list entry)))))
+    (let* ((name (if (listp name-and-options)
+                     (first name-and-options)
+                     name-and-options))
+           (options (when (listp name-and-options)
+                      (rest name-and-options)))
+           (conc-name (destructuring-bind (&optional key conc-name)
+                          (extract-struct-option options :conc-name)
+                        (cond ((and key conc-name) (symbol-name conc-name))
+                              ((and key (not conc-name)) "")
+                              (t (concatenate 'string (symbol-name name) "-")))))
+           (copier (destructuring-bind (&optional key (copier nil has-copier-p))
+                       (extract-struct-option options :copier)
+                     (if has-copier-p
+                         copier
+                         (intern (concatenate 'string "COPY-" (symbol-name name))
+                                 (symbol-package name)))))
+           (type (destructuring-bind (&optional key type)
+                     (extract-struct-option options :type)
+                   (declare (ignore key))
+                   type))
+           ;; initial-offset must default to 0 if :type was given
+           (initial-offset (destructuring-bind (&optional key initial-offset)
+                               (extract-struct-option options :initial-offset)
+                             (declare (ignore key))
+                             (cond (initial-offset initial-offset)
+                                   (type 0))))
+           (named (or (not type) (when (extract-struct-option options :named) t)))
+           (predicate (destructuring-bind (&optional key (predicate nil has-predicate-p))
+                          (extract-struct-option options :predicate)
+                        (if has-predicate-p
+                            predicate
+                            (intern (concatenate 'string (symbol-name name) "-P")
+                                    (symbol-package name)))))
+           (print-function (destructuring-bind (&optional key print-function)
+                               (extract-struct-option options :print-function)
+                             (declare (ignore key))
+                             print-function))
+           (print-object (destructuring-bind (&optional key print-object)
+                             (extract-struct-option options :print-object)
+                           (declare (ignore key))
+                           print-object))
+           (docstring (if (stringp (first slots))
+                          (first slots)
+                          nil))
+           (slots (if (stringp (first slots))
+                      (rest slots)
+                      slots)))
+      (make-instance 'struct-node
+                     :name name
+                     :docstring docstring
+                     :conc-name conc-name
+                     :copier copier
+                     :initial-offset initial-offset
+                     :type type
+                     :named named
+                     :predicate predicate
+                     :print-function print-function
+                     :print-object print-object
+                     :slots (loop for slot in slots collecting
+                                 (parse-struct-slot slot))))))
 
 ;;; CFFI parsers
 


### PR DESCRIPTION
Adds parsing for all of the options that can be used in ```defstruct```, which are


* ```:conc-name```
* ```:constructor```
* ```:copier```
* ```:initial-offset```
* ```:named```
* ```:predicate```
* ```:print-function```
* ```:print-object```
* ```:type```

Most of them are fairly simple. But some require thought on how to represent in the resulting ```struct-node``` class. I'm not sure the way I did them was best (they might need to be changed). I implemented

* ```:conc-name``` as a string
* ```constructor``` as the symbol or if it is a boa-constructor like ```(make-foo a b c)```
* ```include``` as two slots ```include-name``` for the symbol name of the included struct and ```include-slots``` for the list of slot description overrides.


For each option, I tried all the ways they could be passed and still be considered valid based on the text in the draft of the ANSI standard.