### PR TITLE
Made the parsing add the accessor for struct slots from the struct's …

### DIFF
--- a/src/equal.lisp
+++ b/src/equal.lisp
@@ -46,6 +46,7 @@
        (equal (slot-or-nil a 'type) (slot-or-nil b 'type))
        (equal (multiple-value-list (slot-initform a))
               (multiple-value-list (slot-initform b)))
+       (equal (struct-slot-accessor a) (struct-slot-accessor b))
        (call-next-method)))
 
 (define-equality (a b class-slot-node)

--- a/src/nodes.lisp
+++ b/src/nodes.lisp
@@ -67,7 +67,12 @@
               :initarg :read-only
               :type boolean
               :initform nil
-              :documentation "Whether the slot is readonly or not."))
+              :documentation "Whether the slot is readonly or not.")
+   (accessor :reader struct-slot-accessor
+             :initarg :accessor
+             :initform nil
+             :type symbol
+             :documentation "The slot's accessor."))
   (:documentation "A structure's slot."))
 
 (defclass class-slot-node (documentation-node)

--- a/src/package.lisp
+++ b/src/package.lisp
@@ -47,6 +47,7 @@
            ;; Slots
            :struct-slot-type
            :struct-slot-read-only
+           :struct-slot-accessor
            :slot-accessors
            :slot-readers
            :slot-writers


### PR DESCRIPTION
Makes the parsing add the slot accessor to the slot nodes using conc-name and the slot name (e.g. slot a of foo's accessor is ```foo-a```).

Honestly, this PR is a bit of a hack. I had to make it so that ```parse-struct-slot``` could be passed the conc-name and the package as extra arguments in order to construct it. Maybe a better way can be thought of.