### PR TITLE
Fix missing lambda-list of cffi functions defined without docstrings.

### DIFF
--- a/docparser-test.asd
+++ b/docparser-test.asd
@@ -2,7 +2,10 @@
   :author "Fernando Borretti <eudoxiahp@gmail.com>"
   :license "MIT"
   :depends-on (:docparser
-               :fiveam)
+               :fiveam
+               ;; in order to refer sybmols from the
+               ;; docparser-test-system package:
+               :docparser-test-system)
   :components ((:module "t"
                 :serial t
                 :components

--- a/src/parsers.lisp
+++ b/src/parsers.lisp
@@ -279,7 +279,7 @@ Correctly handles bodies where the first form is a declaration."
                        nil))
         (args (if (stringp (first args))
                   (rest args)
-                  nil)))
+                  args)))
     (make-instance 'cffi-function
                    :name name
                    :docstring docstring

--- a/t/docparser.lisp
+++ b/t/docparser.lisp
@@ -183,6 +183,21 @@
                  (list :a :b :c))))
     (test-node-equality nodes)))
 
+(test cffi-function-without-docstring
+  (let* ((index (docparser:parse :docparser-test-system))
+         (nodes (docparser:query index
+                                 :package-name :docparser-test-system
+                                 :symbol-name '#:printf-without-docstring))
+         (func (find 'docparser:cffi-function nodes :key 'type-of)))
+    (is (equal (docparser:operator-lambda-list func)
+               '((docparser-test-system::control :string) &rest)))
+    (is (equal (docparser:node-name func)
+               'docparser-test-system::printf-without-docstring))
+    (is (equal (docparser:cffi-function-return-type func)
+               :int))
+    (is (null (docparser:node-docstring func)))
+    (is (not (docparser:operator-setf-p func)))))
+
 (test queries
   (let ((*index* (docparser:parse :docparser-test-system)))
     (let ((result (docparser:query *index* :symbol-name "VAR")))

--- a/t/test-system.lisp
+++ b/t/test-system.lisp
@@ -99,3 +99,7 @@
 (cffi:defcenum nums "docstring" :a :b (:c 3))
 
 (cffi:defbitfield bits "docstring" :a :b (:c #x0200))
+
+(cffi:defcfun (printf-without-docstring "printf") :int
+  (control :string) &rest)
+


### PR DESCRIPTION
If cffi function is defined without docstring, the `cffi-functoin` node created for it has `nil` lambda list. Due to typo in the parsing code.

A test is added. Without the fix in parsers.lisp the test fail; with the fix it passes.
The rest of the test suite works as before.

As you see, the test is not relying of the parsing node to be at specific integer position in the index, as most of the testsuite does - that seems fragile (see #29). Instead the new tes just queries for the needed node.

